### PR TITLE
Remove download options and fix audio paths

### DIFF
--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -9,28 +9,24 @@ import {
 } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { ChevronLeft, ChevronRight, Search, Download, Eye, EyeOff } from 'lucide-react';
+import { ChevronLeft, ChevronRight, Search } from 'lucide-react';
 
 const DataTable = ({ 
   title = "Data Table", 
   data = [], 
   columns = [], 
   searchable = true,
-  downloadable = true,
   pageSize = 10,
-  toggleableColumns = [],
-  hiddenColumns = [],
-  onColumnVisibilityChange = () => {}
+  hiddenColumns = []
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [searchTerm, setSearchTerm] = useState('');
   const [sortConfig, setSortConfig] = useState({ key: null, direction: 'asc' });
-  const [localHiddenColumns, setLocalHiddenColumns] = useState(hiddenColumns);
 
   // Filter visible columns based on hidden columns
   const visibleColumns = useMemo(() => {
-    return columns.filter(column => !localHiddenColumns.includes(column.key));
-  }, [columns, localHiddenColumns]);
+    return columns.filter(column => !hiddenColumns.includes(column.key));
+  }, [columns, hiddenColumns]);
 
   // Filter data based on search term
   const filteredData = useMemo(() => {
@@ -71,47 +67,7 @@ const DataTable = ({
     }));
   };
 
-  const handleDownload = () => {
-    const csvContent = [
-      visibleColumns.map(col => col.header).join(','),
-      ...data.map(row => visibleColumns.map(col => {
-        const value = row[col.key];
-        // Handle complex objects by converting to string
-        if (typeof value === 'object' && value !== null) {
-          return JSON.stringify(value).replace(/,/g, ';');
-        }
-        return value || '';
-      }).join(','))
-    ].join('\\n');
-    
-    const blob = new Blob([csvContent], { type: 'text/csv' });
-    const url = window.URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = `${title.replace(/\\s+/g, '_').toLowerCase()}.csv`;
-    a.click();
-    window.URL.revokeObjectURL(url);
-  };
-
-  const toggleColumnVisibility = (columnKey) => {
-    const newHiddenColumns = localHiddenColumns.includes(columnKey)
-      ? localHiddenColumns.filter(key => key !== columnKey)
-      : [...localHiddenColumns, columnKey];
-    
-    setLocalHiddenColumns(newHiddenColumns);
-    onColumnVisibilityChange(newHiddenColumns);
-  };
-
-  // Get toggleable columns (exclude the first column which should always be visible)
-  // Determine which columns can be toggled. If the caller didn't
-  // specify any, default to all except the first column so the
-  // primary column is always visible.
-  const toggleableColumnDefs = useMemo(() => {
-    if (toggleableColumns && toggleableColumns.length > 0) {
-      return columns.filter((col) => toggleableColumns.includes(col.key));
-    }
-    return columns.slice(1);
-  }, [columns, toggleableColumns]);
+  // Column visibility controls and CSV download have been removed.
 
   return (
     <div className="bg-white rounded-lg shadow-lg p-6">
@@ -132,39 +88,9 @@ const DataTable = ({
             </div>
           )}
           
-          {downloadable && (
-            <Button onClick={handleDownload} variant="outline" className="flex items-center gap-2">
-              <Download size={16} />
-              Download CSV
-            </Button>
-          )}
         </div>
       </div>
 
-      {/* Column Visibility Controls */}
-      {toggleableColumnDefs.length > 0 && (
-        <div className="mb-4 p-4 bg-gray-50 rounded-lg">
-          <h4 className="text-sm font-medium text-gray-700 mb-3">Show/Hide Columns:</h4>
-          <div className="flex flex-wrap gap-2">
-            {toggleableColumnDefs.map((column) => (
-              <Button
-                key={column.key}
-                variant={localHiddenColumns.includes(column.key) ? "outline" : "default"}
-                size="sm"
-                onClick={() => toggleColumnVisibility(column.key)}
-                className="flex items-center gap-2"
-              >
-                {localHiddenColumns.includes(column.key) ? (
-                  <EyeOff size={14} />
-                ) : (
-                  <Eye size={14} />
-                )}
-                {column.header}
-              </Button>
-            ))}
-          </div>
-        </div>
-      )}
 
       {/* Table */}
       <div className="overflow-x-auto">

--- a/src/components/InlineAudioPlayer.jsx
+++ b/src/components/InlineAudioPlayer.jsx
@@ -1,11 +1,11 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Play, Pause, Volume2, VolumeX, Download } from 'lucide-react';
+import { Play, Pause, Volume2, VolumeX } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
 const InlineAudioPlayer = ({ 
   audioSrc, 
   title = "Audio Sample",
-  showDownload = true,
+  showDownload = false,
   showTitle = true,
   compact = false 
 }) => {
@@ -70,15 +70,6 @@ const InlineAudioPlayer = ({
     audio.currentTime = percent * duration;
   };
 
-  const handleDownload = () => {
-    const link = document.createElement('a');
-    link.href = audioSrc;
-    link.download = title.replace(/\s+/g, '_').toLowerCase() + '.mp3';
-    link.click();
-  };
-
-  const formatTime = (time) => {
-    if (isNaN(time)) return '0:00';
     const minutes = Math.floor(time / 60);
     const seconds = Math.floor(time % 60);
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;
@@ -132,16 +123,6 @@ const InlineAudioPlayer = ({
           </div>
         </div>
 
-        {showDownload && (
-          <Button
-            size="sm"
-            variant="ghost"
-            onClick={handleDownload}
-            className="h-6 w-6 p-0 flex-shrink-0"
-          >
-            <Download size={12} />
-          </Button>
-        )}
       </div>
     );
   }
@@ -196,16 +177,6 @@ const InlineAudioPlayer = ({
           {isMuted ? <VolumeX size={16} /> : <Volume2 size={16} />}
         </Button>
 
-        {showDownload && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleDownload}
-            className="h-8 w-8 p-0"
-          >
-            <Download size={16} />
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/src/components/TableSection.jsx
+++ b/src/components/TableSection.jsx
@@ -1,23 +1,7 @@
-import React, { useState } from 'react';
+import React from 'react';
 import DataTable from './DataTable';
 
 const TableSection = ({ tableConfig }) => {
-  const [hiddenColumnsState, setHiddenColumnsState] = useState(() => {
-    const initialState = {};
-    tableConfig.tables.forEach((table, index) => {
-      if (table.toggleableColumns) {
-        initialState[index] = []; // Initialize all toggleable columns as visible
-      }
-    });
-    return initialState;
-  });
-
-  const handleColumnVisibilityChange = (tableIndex, newHiddenColumns) => {
-    setHiddenColumnsState(prev => ({
-      ...prev,
-      [tableIndex]: newHiddenColumns
-    }));
-  };
 
   return (
     <section className="py-16 bg-gray-50">
@@ -44,14 +28,8 @@ const TableSection = ({ tableConfig }) => {
                 data={table.data}
                 columns={table.columns}
                 searchable={table.searchable !== false}
-                downloadable={table.downloadable !== false}
                 pageSize={table.pageSize || 10}
-                // Pass toggleable columns and current hidden state
-                toggleableColumns={table.toggleableColumns || []}
-                hiddenColumns={hiddenColumnsState[index] || []}
-                onColumnVisibilityChange={(newHiddenColumns) => 
-                  handleColumnVisibilityChange(index, newHiddenColumns)
-                }
+                hiddenColumns={table.hiddenColumns || []}
               />
             ))}
           </div>

--- a/src/data/audio-table-config.jsx
+++ b/src/data/audio-table-config.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import InlineAudioPlayer from '../components/InlineAudioPlayer';
 import ExpandableText from '../components/ExpandableText';
 import preprocessedData from '../assets/preprocessedData.json';
+import sample1Audio from '../assets/audio/sample_1.wav';
 
 // Example configuration showing how to add inline audio to tables
 export const audioTableConfig = {
@@ -11,12 +12,7 @@ export const audioTableConfig = {
   tables: [
     {
       title: "Kids WFST Dysfluency Samples",
-      toggleableColumns: [ // NEW: Define columns that can be shown/hidden
-        'phn_transcription',
-        'llm_advice'
-      ],
       searchable: true,
-      downloadable: true,
       pageSize: 10,
       columns: [
         { 
@@ -75,7 +71,7 @@ export const audioTableConfig = {
       ],
       data: [
         {
-          audio_file: "../assets/audio/sample_1.wav",
+          audio_file: sample1Audio,
           sample_id: "sample_1",
           speaker: "Child A",
           phn_transcription: preprocessedData["sample_1"]?.phn_transcription || "",


### PR DESCRIPTION
## Summary
- remove CSV export and column toggling from `DataTable`
- simplify `TableSection` accordingly
- hide download control in `InlineAudioPlayer`
- import audio asset in `audio-table-config`

## Testing
- `pnpm lint` *(fails: Request was cancelled due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685bc38f282c8330a6759bdeebd0d732