### PR TITLE
Fix missing formatTime function in InlineAudioPlayer

### DIFF
--- a/src/components/InlineAudioPlayer.jsx
+++ b/src/components/InlineAudioPlayer.jsx
@@ -70,6 +70,8 @@ const InlineAudioPlayer = ({
     audio.currentTime = percent * duration;
   };
 
+  const formatTime = (time) => {
+    if (isNaN(time)) return '0:00';
     const minutes = Math.floor(time / 60);
     const seconds = Math.floor(time % 60);
     return `${minutes}:${seconds.toString().padStart(2, '0')}`;


### PR DESCRIPTION
## Summary
- reintroduce the `formatTime` helper after `handleSeek`

## Testing
- `npm run lint` *(fails: 'showDownload' is assigned a value but never used)*

------
https://chatgpt.com/codex/tasks/task_e_685bc864c7008330b0b448ba30722e21