### PR TITLE
Add interactive dysfluency highlighting

### DIFF
--- a/src/components/DataTable.jsx
+++ b/src/components/DataTable.jsx
@@ -1,4 +1,18 @@
 import React, { useState, useMemo } from 'react';
+
+export const RowHighlightContext = React.createContext({
+  highlight: null,
+  setHighlight: () => {}
+});
+
+const RowHighlightProvider = ({ children }) => {
+  const [highlight, setHighlight] = useState(null);
+  return (
+    <RowHighlightContext.Provider value={{ highlight, setHighlight }}>
+      {children}
+    </RowHighlightContext.Provider>
+  );
+};
 import {
   Table,
   TableBody,
@@ -118,13 +132,15 @@ const DataTable = ({
           <TableBody>
             {paginatedData.length > 0 ? (
               paginatedData.map((row, index) => (
-                <TableRow key={index} className="hover:bg-gray-50">
-                  {visibleColumns.map((column) => (
-                    <TableCell key={column.key} className="py-3">
-                      {column.render ? column.render(row[column.key], row) : row[column.key]}
-                    </TableCell>
-                  ))}
-                </TableRow>
+                <RowHighlightProvider key={index}>
+                  <TableRow className="hover:bg-gray-50">
+                    {visibleColumns.map((column) => (
+                      <TableCell key={column.key} className="py-3">
+                        {column.render ? column.render(row[column.key], row) : row[column.key]}
+                      </TableCell>
+                    ))}
+                  </TableRow>
+                </RowHighlightProvider>
               ))
             ) : (
               <TableRow>

--- a/src/components/ErrorStatsBadges.jsx
+++ b/src/components/ErrorStatsBadges.jsx
@@ -1,0 +1,35 @@
+import React, { useContext } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { RowHighlightContext } from './DataTable';
+
+const colorMap = {
+  sub: 'bg-yellow-100 text-yellow-800',
+  del: 'bg-red-100 text-red-800',
+  ins: 'bg-green-100 text-green-800',
+};
+
+const ErrorStatsBadges = ({ stats = {} }) => {
+  const { setHighlight } = useContext(RowHighlightContext);
+  const items = [
+    { key: 'sub', label: 'Substitutions', value: stats.substitutions },
+    { key: 'del', label: 'Deletions', value: stats.deletions },
+    { key: 'ins', label: 'Insertions', value: stats.insertions },
+  ];
+
+  return (
+    <div className="flex flex-col space-y-1">
+      {items.map(item => (
+        <Badge
+          key={item.key}
+          className={`${colorMap[item.key]} cursor-pointer px-2 rounded-full w-fit`}
+          onMouseEnter={() => setHighlight(item.key)}
+          onMouseLeave={() => setHighlight(null)}
+        >
+          {item.label}: {item.value}
+        </Badge>
+      ))}
+    </div>
+  );
+};
+
+export default ErrorStatsBadges;

--- a/src/components/HighlightedTranscription.jsx
+++ b/src/components/HighlightedTranscription.jsx
@@ -1,0 +1,68 @@
+import React, { useMemo, useContext } from 'react';
+import { cn } from '@/lib/utils';
+import { RowHighlightContext } from './DataTable';
+
+// Parse transcription string with <DEL>, <SUB>, <INS> tags
+function parseTranscription(text) {
+  if (!text) return [];
+  const normalized = text.replace(/[`\u2018\u2019]/g, "'");
+  const regex = /<\\?DEL>|<\\?SUB>|<\\?INS>|'[^']+'/g;
+  const tokens = [];
+  let current = null;
+  for (const match of normalized.matchAll(regex)) {
+    const token = match[0];
+    switch (token) {
+      case '<DEL>':
+        current = 'del';
+        break;
+      case '<\\DEL>':
+        current = null;
+        break;
+      case '<SUB>':
+        current = 'sub';
+        break;
+      case '<\\SUB>':
+        current = null;
+        break;
+      case '<INS>':
+        current = 'ins';
+        break;
+      case '<\\INS>':
+        current = null;
+        break;
+      default:
+        tokens.push({ text: token.replace(/'/g, ''), type: current });
+    }
+  }
+  return tokens;
+}
+
+const colorMap = {
+  del: 'bg-red-100 text-red-800',
+  sub: 'bg-yellow-100 text-yellow-800',
+  ins: 'bg-green-100 text-green-800',
+};
+
+const HighlightedTranscription = ({ text }) => {
+  const tokens = useMemo(() => parseTranscription(text), [text]);
+  const { highlight } = useContext(RowHighlightContext);
+  return (
+    <p className="text-sm text-gray-700 flex flex-wrap gap-1">
+      {tokens.map((tok, idx) => (
+        <span
+          key={idx}
+          data-type={tok.type}
+          className={cn(
+            tok.type && colorMap[tok.type],
+            tok.type && 'px-1 rounded',
+            highlight === tok.type && 'ring-2 ring-offset-2'
+          )}
+        >
+          {tok.text}
+        </span>
+      ))}
+    </p>
+  );
+};
+
+export default HighlightedTranscription;

--- a/src/components/TranscriptionCell.jsx
+++ b/src/components/TranscriptionCell.jsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import HighlightedTranscription from './HighlightedTranscription';
+
+const TranscriptionCell = ({ text, lines = 2 }) => {
+  const [expanded, setExpanded] = useState(false);
+  if (!text) return null;
+
+  const toggle = () => setExpanded(prev => !prev);
+  const clamped = expanded ? '' : `line-clamp-${lines}`;
+
+  return (
+    <div className="space-y-1 max-w-xs">
+      <div className={cn('whitespace-pre-wrap', clamped)}>
+        <HighlightedTranscription text={text} />
+      </div>
+      {text.length > 0 && (
+        <Button variant="link" size="sm" className="p-0 h-auto" onClick={toggle}>
+          {expanded ? 'Show Less' : 'Show More'}
+        </Button>
+      )}
+    </div>
+  );
+};
+
+export default TranscriptionCell;

--- a/src/data/audio-table-config.jsx
+++ b/src/data/audio-table-config.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import InlineAudioPlayer from '../components/InlineAudioPlayer';
 import ExpandableText from '../components/ExpandableText';
+import HighlightedTranscription from '../components/HighlightedTranscription';
+import ErrorStatsBadges from '../components/ErrorStatsBadges';
+import TranscriptionCell from '../components/TranscriptionCell';
 import preprocessedData from '../assets/preprocessedData.json';
 import sample1Audio from '../assets/audio/sample_1.wav';
 import sample2Audio from '../assets/audio/sample_2.wav';
@@ -37,7 +40,7 @@ export const audioTableConfig = {
           header: 'Phoneme Transcription',
           sortable: false,
           render: (value) => (
-            <ExpandableText text={value} />
+            <TranscriptionCell text={value} />
           )
         },
         // Detailed Error Statistics
@@ -46,11 +49,7 @@ export const audioTableConfig = {
           header: 'Error Statistics',
           sortable: false,
           render: (stats) => (
-            <div className="flex flex-col space-y-1">
-              <div className="text-xs text-gray-600">Substitutions: {stats.substitutions}</div>
-              <div className="text-xs text-gray-600">Deletions: {stats.deletions}</div>
-              <div className="text-xs text-gray-600">Insertions : {stats.insertions}</div>
-            </div>
+            <ErrorStatsBadges stats={stats} />
           )
         },
         // score


### PR DESCRIPTION
## Summary
- highlight deletion, insertion, and substitution tokens
- use badges for error stats with matching colors
- keep row-level highlight state to link error stats with transcription

## Testing
- `pnpm lint` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_685ca70106148330a866e1e00ad5d55c