### PR TITLE
Remove global outlines and refine show more buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -112,7 +112,10 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border;
+  }
+  *:focus-visible {
+    @apply outline-ring/50;
   }
   body {
     @apply bg-background text-foreground;

--- a/src/components/ExpandableText.jsx
+++ b/src/components/ExpandableText.jsx
@@ -1,9 +1,20 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 const ExpandableText = ({ text, lines = 2 }) => {
   const [expanded, setExpanded] = useState(false);
+  const [clampable, setClampable] = useState(false);
+  const textRef = useRef(null);
+  useEffect(() => {
+    if (!text) return;
+    const el = textRef.current;
+    if (!el) return;
+    if (!expanded) {
+      setClampable(el.scrollHeight > el.clientHeight + 1);
+    }
+  }, [text, lines, expanded]);
+
   if (!text) return null;
 
   const toggle = () => setExpanded((prev) => !prev);
@@ -11,10 +22,13 @@ const ExpandableText = ({ text, lines = 2 }) => {
 
   return (
     <div className="space-y-1 max-w-xs">
-      <p className={cn('text-sm text-gray-700 whitespace-pre-wrap', clamped)}>
+      <p
+        ref={textRef}
+        className={cn('text-sm text-gray-700 whitespace-pre-wrap', clamped)}
+      >
         {text}
       </p>
-      {text.length > 0 && (
+      {clampable && (
         <Button
           variant="link"
           size="sm"

--- a/src/components/TranscriptionCell.jsx
+++ b/src/components/TranscriptionCell.jsx
@@ -1,10 +1,21 @@
-import React, { useState } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 import HighlightedTranscription from './HighlightedTranscription';
 
 const TranscriptionCell = ({ text, lines = 2 }) => {
   const [expanded, setExpanded] = useState(false);
+  const [clampable, setClampable] = useState(false);
+  const textRef = useRef(null);
+  useEffect(() => {
+    if (!text) return;
+    const el = textRef.current;
+    if (!el) return;
+    if (!expanded) {
+      setClampable(el.scrollHeight > el.clientHeight + 1);
+    }
+  }, [text, lines, expanded]);
+
   if (!text) return null;
 
   const toggle = () => setExpanded(prev => !prev);
@@ -12,10 +23,10 @@ const TranscriptionCell = ({ text, lines = 2 }) => {
 
   return (
     <div className="space-y-1 max-w-xs">
-      <div className={cn('whitespace-pre-wrap', clamped)}>
+      <div ref={textRef} className={cn('whitespace-pre-wrap', clamped)}>
         <HighlightedTranscription text={text} />
       </div>
-      {text.length > 0 && (
+      {clampable && (
         <Button variant="link" size="sm" className="p-0 h-auto" onClick={toggle}>
           {expanded ? 'Show Less' : 'Show More'}
         </Button>


### PR DESCRIPTION
## Summary
- clean up Tailwind base layer styling
- show 'Show More' button only when text is clamped in ExpandableText and TranscriptionCell components

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685cafc4913083308452b3601a18afe8