### PR TITLE
Make advice view always scrollable

### DIFF
--- a/src/components/ExpandableText.jsx
+++ b/src/components/ExpandableText.jsx
@@ -14,21 +14,12 @@ import { marked } from 'marked';
 
 const ExpandableText = ({ text, lines = 2 }) => {
   const [expanded, setExpanded] = useState(false);
-  const [clampable, setClampable] = useState(false);
   const [open, setOpen] = useState(false);
   const [scrollPos, setScrollPos] = useState(0);
   const [scrollMax, setScrollMax] = useState(0);
   const textRef = useRef(null);
   const scrollRef = useRef(null);
   const html = useMemo(() => (text ? marked.parse(text) : ''), [text]);
-  useEffect(() => {
-    if (!text) return;
-    const el = textRef.current;
-    if (!el) return;
-    if (!expanded) {
-      setClampable(el.scrollHeight > el.clientHeight + 1);
-    }
-  }, [text, lines, expanded]);
 
   useEffect(() => {
     if (!open) return;
@@ -58,52 +49,50 @@ const ExpandableText = ({ text, lines = 2 }) => {
         className={cn('text-sm text-gray-700 whitespace-pre-wrap', clamped)}
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      {clampable && (
-        <div className="flex gap-2">
-          <Button
-            variant="link"
-            size="sm"
-            className="p-0 h-auto"
-            onClick={toggle}
-          >
-            {expanded ? 'Show Less' : 'Show More'}
-          </Button>
-          <Dialog open={open} onOpenChange={setOpen}>
-            <DialogTrigger asChild>
-              <Button variant="link" size="sm" className="p-0 h-auto">
-                View All
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-lg">
-              <DialogHeader>
-                <DialogTitle>Advice</DialogTitle>
-              </DialogHeader>
-              <div className="flex items-start gap-2">
-                <ScrollArea ref={scrollRef} className="max-h-80 flex-1">
-                  <div
-                    className="text-sm text-gray-700 whitespace-pre-wrap"
-                    dangerouslySetInnerHTML={{ __html: html }}
-                  />
-                </ScrollArea>
-                <Slider
-                  orientation="vertical"
-                  className="h-80"
-                  min={0}
-                  max={scrollMax}
-                  value={[scrollPos]}
-                  onValueChange={(val) => {
-                    const container = scrollRef.current?.querySelector('[data-slot="scroll-area-viewport"]');
-                    if (container) {
-                      container.scrollTop = val[0];
-                    }
-                    setScrollPos(val[0]);
-                  }}
+      <div className="flex gap-2">
+        <Button
+          variant="link"
+          size="sm"
+          className="p-0 h-auto"
+          onClick={toggle}
+        >
+          {expanded ? 'Show Less' : 'Show More'}
+        </Button>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button variant="link" size="sm" className="p-0 h-auto">
+              View All
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-lg">
+            <DialogHeader>
+              <DialogTitle>Advice</DialogTitle>
+            </DialogHeader>
+            <div className="flex items-start gap-2">
+              <ScrollArea ref={scrollRef} className="max-h-80 flex-1">
+                <div
+                  className="text-sm text-gray-700 whitespace-pre-wrap"
+                  dangerouslySetInnerHTML={{ __html: html }}
                 />
-              </div>
-            </DialogContent>
-          </Dialog>
-        </div>
-      )}
+              </ScrollArea>
+              <Slider
+                orientation="vertical"
+                className="h-80"
+                min={0}
+                max={scrollMax}
+                value={[scrollPos]}
+                onValueChange={(val) => {
+                  const container = scrollRef.current?.querySelector('[data-slot="scroll-area-viewport"]');
+                  if (container) {
+                    container.scrollTop = val[0];
+                  }
+                  setScrollPos(val[0]);
+                }}
+              />
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- always show the "View All" dialog and slider in ExpandableText
- remove overflow checking logic

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685df5eddfb4833091e550f0e8c1a7a2