### PR TITLE
Sanitize markdown output

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
     "marked": "^9.1.6",
+    "dompurify": "^3.0.6",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-day-picker": "8.10.1",

--- a/src/components/ExpandableText.jsx
+++ b/src/components/ExpandableText.jsx
@@ -11,6 +11,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { Slider } from '@/components/ui/slider';
 import { cn } from '@/lib/utils';
 import { marked } from 'marked';
+import DOMPurify from 'dompurify';
 
 const ExpandableText = ({ text, lines = 2 }) => {
   const [open, setOpen] = useState(false);
@@ -18,7 +19,11 @@ const ExpandableText = ({ text, lines = 2 }) => {
   const [scrollMax, setScrollMax] = useState(0);
   const textRef = useRef(null);
   const scrollRef = useRef(null);
-  const html = useMemo(() => (text ? marked.parse(text) : ''), [text]);
+  const html = useMemo(() => {
+    if (!text) return '';
+    const raw = marked.parse(text);
+    return DOMPurify.sanitize(raw);
+  }, [text]);
 
   useEffect(() => {
     if (!open) return;


### PR DESCRIPTION
## Summary
- sanitize `ExpandableText` markdown with DOMPurify before injecting into the DOM
- declare DOMPurify dependency

## Testing
- `pnpm lint` *(fails: Request was cancelled due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_685e020152008330aafcd661a2754884