### PR TITLE
Always show advice dialog even without text

### DIFF
--- a/src/components/ExpandableText.jsx
+++ b/src/components/ExpandableText.jsx
@@ -18,7 +18,11 @@ const ExpandableText = ({ text, lines = 2 }) => {
   const [scrollMax, setScrollMax] = useState(0);
   const textRef = useRef(null);
   const scrollRef = useRef(null);
-  const html = useMemo(() => (text ? marked.parse(text) : ''), [text]);
+  const placeholder = 'No advice available';
+  const html = useMemo(
+    () => (text ? marked.parse(text) : `<p>${placeholder}</p>`),
+    [text]
+  );
 
   useEffect(() => {
     if (!open) return;
@@ -34,7 +38,7 @@ const ExpandableText = ({ text, lines = 2 }) => {
     return () => container.removeEventListener('scroll', handleScroll);
   }, [open, html]);
 
-  if (!text) return null;
+
 
   const clamped = `line-clamp-${lines}`;
 


### PR DESCRIPTION
## Summary
- ensure `ExpandableText` still renders even when no text is passed
- render placeholder text inside the dialog when advice is unavailable

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685e020aa37c83308db9381a8cc4ae13